### PR TITLE
Release1.0[RC]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release:
 	xcopy /y tu_optimize.exe tu_optimize
 	xcopy /y rapidxml_license.txt tu_optimize
 	xcopy /y tu_optimize_license.txt tu_optimize
-	xcopy /y README.md tu_optimize\readme.txt
+	copy README.md tu_optimize\readme.txt
 	xcopy /y SimpleTUOptimizeStarter.ahk tu_optimize
 	xcopy /y data\cardabbrs_template.txt tu_optimize\data
 	xcopy /y data\customdecks_template.txt tu_optimize\data

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ win%: 22.3022 (223022 / 1000000)
 stall%: 1.0532 (10532 / 1000000)
 loss%: 76.6446 (766446 / 1000000)
 </pre>
+* Added battleground effect Heal 1-3
+<pre>
+tu_optimize "Alaric, Vigil(5)" "Obama, Terraformer(5)" -e "Heal 1" sim 100000
+Your Deck: [RECd+l] Alaric, Vigil, Vigil, Vigil, Vigil, Vigil
+Enemy's Deck: [SoOe+l] Barracus, Terraformer, Terraformer, Terraformer, Terraformer, Terraformer
+Effect: Heal 1
+win%: 98.553 (98553 / 100000)
+stall%: 1.39 (1390 / 100000)
+loss%: 0.057 (57 / 100000)
+</pre>
 
 ##Version 0.10.1
 * [FIX] Played cards started with evade_left 0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deck Simulator and Optimizer for Tyrant Unleashed!
 * SimpleTUOptimizeStarter Help to show build in help
 * SimpleTUOptimizeStarter Web to open http://zachanassian.github.io/tu_optimize/
 * [FIX] SimpleTUOptimizeStarter output window should no longer close immediatly
-* ownedcards.txt sigle copy of a card no longer requires count (1)
+* ownedcards.txt single copy of a card no longer requires count (1)
 * Added battleground effect Poison 1-3
 <pre>
 tu_optimize.exe "Barracus, Starformer(2)" "Constantine, Vigil(10)" -e "Poison 2" sim 10000

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ win%: 99.75 (9975 / 10000)
 stall%: 0.07 (7 / 10000)
 loss%: 0.18 (18 / 10000)
 </pre>
+* Added battleground effect Leech 1-3
+<pre>
+tu_optimize.exe "Nex, Apex(10)" "Obama, SF(5)" -e "Leech 3" sim 1000000
+Your Deck: [S0CC+q] Nexor, Apex, Apex, Apex, Apex, Apex, Apex, Apex, Apex, Apex, Apex
+Enemy's Deck: [SoO6+l] Barracus, Starformer, Starformer, Starformer, Starformer, Starformer
+Effect: Leech 3
+win%: 22.3022 (223022 / 1000000)
+stall%: 1.0532 (10532 / 1000000)
+loss%: 76.6446 (766446 / 1000000)
+</pre>
 
 ##Version 0.10.1
 * [FIX] Played cards started with evade_left 0

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 Deck Simulator and Optimizer for Tyrant Unleashed!
 
 ##Version 1.0
-* SimpleTUOptimizeStarter.exe no longer needs quotes
-* SimpleTUOptimizeStarter.exe will close all his opened output windows on exit or window close
+* SimpleTUOptimizeStarter no longer needs quotes
+* SimpleTUOptimizeStarter will close all his opened output windows on exit or window close
+* SimpleTUOptimizeStarter Help to show build in help
+* SimpleTUOptimizeStarter Web to open http://zachanassian.github.io/tu_optimize/
+* [FIX] SimpleTUOptimizeStarter output window should no longer close immediatly
 * ownedcards.txt sigle copy of a card no longer requires count (1)
 * Added battleground effect Poison 1-3
 <pre>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,46 @@ win%: 98.553 (98553 / 100000)
 stall%: 1.39 (1390 / 100000)
 loss%: 0.057 (57 / 100000)
 </pre>
+* Added battleground effect Evade 1-3
+<pre>
+tu_optimize "Alaric, Blitz(6)" "Barracus, Apex" -e "Evade 1" sim 10000
+Your Deck: [REIJ+m] Alaric, Blitz, Blitz, Blitz, Blitz, Blitz, Blitz
+Enemy's Deck: [SoCC] Barracus, Apex
+Effect: Evade 1
+win%: 100 (10000 / 10000)
+stall%: 0 (0 / 10000)
+loss%: 0 (0 / 10000)
+</pre>
+* Added battleground effect Counter 1-3
+<pre>
+tu_optimize "Alaric, Vigil(4)" "Halcyon, Windreaver(5)" -e "Counter 1" sim 10000
+Your Deck: [RECd+k] Alaric, Vigil, Vigil, Vigil, Vigil
+Enemy's Deck: [QEIP+l] Halcyon, Windreaver, Windreaver, Windreaver, Windreaver, Windreaver
+Effect: Counter 1
+win%: 25.08 (2508 / 10000)
+stall%: 1.29 (129 / 10000)
+loss%: 73.63 (7363 / 10000)
+</pre>
+* Added battleground effect Berserk 1-3
+<pre>
+tu_optimize "Vex, HA(5)" "Halcyon, Galereaver(3)" -e "Berserk 3" sim 10000
+Your Deck: [QKLQ+l] Typhon Vex, Havoc Alpha, Havoc Alpha, Havoc Alpha, Havoc Alpha, Havoc Alpha
+Enemy's Deck: [QE-QB+j] Halcyon, Galereaver, Galereaver, Galereaver
+Effect: Berserk 3
+win%: 11.92 (1192 / 10000)
+stall%: 15.05 (1505 / 10000)
+loss%: 73.03 (7303 / 10000)
+</pre>
+* Added battleground effect Armor 1-3
+<pre>
+tu_optimize "Alaric, Vigil(3)" "Obama, Apex(5)" -e "Armor 2" sim 10000
+Your Deck: [RECd+j] Alaric, Vigil, Vigil, Vigil
+Enemy's Deck: [SoCC+l] Barracus, Apex, Apex, Apex, Apex, Apex
+Effect: Armored 2
+win%: 73.12 (7312 / 10000)
+stall%: 25.31 (2531 / 10000)
+loss%: 1.57 (157 / 10000)
+</pre>
 
 ##Version 0.10.1
 * [FIX] Played cards started with evade_left 0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 #Tyrant Unleashed Optimizer
 Deck Simulator and Optimizer for Tyrant Unleashed!
 
-##Version ##
+##Version 1.0
+* SimpleTUOptimizeStarter.exe no longer needs quotes
+* SimpleTUOptimizeStarter.exe will close all his opened output windows on exit or window close
+* ownedcards.txt sigle copy of a card no longer requires count (1)
 * Added battleground effect Poison 1-3
 <pre>
 tu_optimize.exe "Barracus, Starformer(2)" "Constantine, Vigil(10)" -e "Poison 2" sim 10000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 #Tyrant Unleashed Optimizer
 Deck Simulator and Optimizer for Tyrant Unleashed!
 
+##Version ##
+* Added battleground effect Poison 1-3
+<pre>
+tu_optimize.exe "Barracus, Starformer(2)" "Constantine, Vigil(10)" -e "Poison 2" sim 10000
+Your Deck: [SoO6+i] Barracus, Starformer, Starformer
+Enemy's Deck: [S6Cd+q] Constantine, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil
+Effect: Poison 2
+win%: 99.75 (9975 / 10000)
+stall%: 0.07 (7 / 10000)
+loss%: 0.18 (18 / 10000)
+</pre>
+
 ##Version 0.10.1
 * [FIX] Played cards started with evade_left 0
 <pre>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #Tyrant Unleashed Optimizer
 Deck Simulator and Optimizer for Tyrant Unleashed!
 
-##Version 1.0
+##Version 1.0[RC]
 * SimpleTUOptimizeStarter no longer needs quotes
 * SimpleTUOptimizeStarter will close all his opened output windows on exit or window close
 * SimpleTUOptimizeStarter Help to show build in help

--- a/SimpleTUOptimizeStarter.ahk
+++ b/SimpleTUOptimizeStarter.ahk
@@ -7,8 +7,8 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 Gui, Add, Text, r5, My Deck:
 Gui, Add, Text, r5, Enemie's Deck:
 Gui, Add, Text, r1, Options:
-Gui, Add, Edit, vMyDeck ym w600 r5, "Cyrus, Medic, Revolver, Imperial APC, Medic, Imperial APC"
-Gui, Add, Edit, vEnemiesDeck w600 r5, "94. Heart of Tartarus"
+Gui, Add, Edit, vMyDeck ym w600 r5, Cyrus, Medic, Revolver, Imperial APC, Medic, Imperial APC
+Gui, Add, Edit, vEnemiesDeck w600 r5, 94. Heart of Tartarus
 Gui, Add, Edit, vSimOptions w600, -r -o climb 10000
 Gui, Add, Button, default r2 w100 x100 y+15 section, Simulate
 Gui, Add, Button, r2 w100 ys xs+200, Exit
@@ -17,7 +17,7 @@ return
 
 ButtonSimulate:
 Gui, Submit
-Run, cmd.exe /c tu_optimize %MyDeck% %EnemiesDeck% %SimOptions% && pause
+Run, cmd.exe /c echo tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && pause
 Gui, Show
 return
 

--- a/SimpleTUOptimizeStarter.ahk
+++ b/SimpleTUOptimizeStarter.ahk
@@ -4,6 +4,9 @@
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
+Menu, MyMenu, Add, Help, MenuHelp
+Menu, MyMenu, Add, Web, MenuWeb
+Gui, Menu, MyMenu
 Gui, Add, Text, r5, My Deck:
 Gui, Add, Text, r5, Enemie's Deck:
 Gui, Add, Text, r1, Options:
@@ -18,6 +21,18 @@ return
 ButtonSimulate:
 Gui, Submit
 Run, cmd.exe /c title TUOptimizeOutput && echo tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && pause
+Gui, Show
+return
+
+MenuHelp:
+Gui, Submit
+Run, cmd.exe /c title TUOptimizeOutput && echo tu_optimize && tu_optimize && pause
+Gui, Show
+return
+
+MenuWeb:
+Gui, Submit
+Run http://zachanassian.github.io/tu_optimize/
 Gui, Show
 return
 

--- a/SimpleTUOptimizeStarter.ahk
+++ b/SimpleTUOptimizeStarter.ahk
@@ -17,10 +17,17 @@ return
 
 ButtonSimulate:
 Gui, Submit
-Run, cmd.exe /c echo tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && pause
+Run, cmd.exe /c title TUOptimizeOutput && echo tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && tu_optimize "%MyDeck%" "%EnemiesDeck%" %SimOptions% && pause
 Gui, Show
 return
 
 GuiClose:
 ButtonExit:
+while true
+{
+  IfWinExist, TUOptimizeOutput
+      WinClose ; use the window found above
+  else
+      break
+}  
 ExitApp

--- a/card.h
+++ b/card.h
@@ -29,6 +29,7 @@ public:
         m_flurry(0),
         m_flying(false),
         m_fusion(false),
+        m_heal(0),
         m_health(0),
         m_hidden(0),
         m_id(0),
@@ -96,6 +97,7 @@ public:
     unsigned m_flurry;
     bool m_flying;
     bool m_fusion;
+    unsigned m_heal;
     unsigned m_health;
     unsigned m_hidden;
     unsigned m_id;

--- a/data/cardabbrs_template.txt
+++ b/data/cardabbrs_template.txt
@@ -1,7 +1,30 @@
-Pet: Petrisis
-HA: Havoc Alpha
-Obama: Barracus
-SF: Starformer
-Nex: Nexor
+AV: Ayrkrane Vik
+BC: Blight Crusher
+BCg: Bolt Crag
+BzP: Blitz Plate
+CA: Crushing Anvil
+CJ: Covert Jet
 Eerie: Narscious the Eerie
+GF: Garrison Fortifier
+HA: Havoc Alpha
+HD: Heart Devourer
+HG: Havoc Genesis
+IT: Indestructible Troop
+MJ: Mach Jet
+MwA: Masterwork Aegis
 NbD: Noble Defiance
+Nex: Nexor
+Obama: Barracus
+PD: Pantheon Disciple
+Pet: Petrisis
+SF: Starformer
+SR: Spiteful Raptor
+SacS: Sacred Sanctuary
+SS: Shining Sanctuary
+TB: Tartarus Brood
+TS: Tartarus Scion
+Vex: Typhon Vex
+VR: Venomous Raptor
+XO: Xeno Overlord
+XS: Xeno Suzerain
+ZH: Zodiac Harbinger

--- a/data/ownedcards_template.txt
+++ b/data/ownedcards_template.txt
@@ -1,7 +1,7 @@
 //put all your cards in a file like this and name it ownedcards.txt
 //you have one copy of Alaric (Level6) and Cyrus (Level6)
-Alaric (1)
-Cyrus (1)
+Alaric
+Cyrus
 //you have two Indebted Vererans Level 1
 Indebted Veteran-1 (2)
 //you can also use abbreviations defined in cardabbrs.txt. Then this could be three Noble Defiances

--- a/sim.cpp
+++ b/sim.cpp
@@ -419,7 +419,10 @@ bool may_change_skill(const Field* fd, const CardStatus* status, const SkillMod:
             switch (status->m_card->m_type)
             {
                 case CardType::commander:
-                    return (fd->effect == Effect::time_surge ||
+                    return (fd->effect == Effect::poison_1 ||
+                            fd->effect == Effect::poison_2 ||
+                            fd->effect == Effect::poison_3 ||
+                            fd->effect == Effect::time_surge ||
                             fd->effect == Effect::friendly_fire ||
                             fd->effect == Effect::genesis ||
                             (fd->effect == Effect::artillery_strike && fd->turn >= 9 && status->m_player == (fd->optimization_mode == OptimizationMode::defense ? 1u : 0u)) ||
@@ -446,6 +449,27 @@ SkillSpec apply_battleground_effect(const Field* fd, const CardStatus* status, c
     const auto& skill = std::get<0>(ss);
     switch (fd->effect)
     {
+        case Effect::poison_1:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_poison, 1, allfactions, true, mod);
+            }
+            break;
+        case Effect::poison_2:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_poison, 2, allfactions, true, mod);
+            }
+            break;
+        case Effect::poison_3:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_poison, 3, allfactions, true, mod);
+            }
+            break;
         case Effect::time_surge:
             // replace other instance of the skill
             if(skill == rush || skill == new_skill)

--- a/sim.cpp
+++ b/sim.cpp
@@ -422,7 +422,19 @@ bool may_change_skill(const Field* fd, const CardStatus* status, const SkillMod:
             switch (status->m_card->m_type)
             {
                 case CardType::commander:
-                    return (fd->effect == Effect::heal_1 ||
+                    return (fd->effect == Effect::armored_1 ||
+                            fd->effect == Effect::armored_2 ||
+                            fd->effect == Effect::armored_3 ||
+                            fd->effect == Effect::berserk_1 ||
+                            fd->effect == Effect::berserk_2 ||
+                            fd->effect == Effect::berserk_3 ||
+                            fd->effect == Effect::counter_1 ||
+                            fd->effect == Effect::counter_2 ||
+                            fd->effect == Effect::counter_3 ||
+                            fd->effect == Effect::evade_1 ||
+                            fd->effect == Effect::evade_2 ||
+                            fd->effect == Effect::evade_3 ||
+                            fd->effect == Effect::heal_1 ||
                             fd->effect == Effect::heal_2 ||
                             fd->effect == Effect::heal_3 ||
                             fd->effect == Effect::leech_1 ||
@@ -459,16 +471,28 @@ SkillSpec apply_battleground_effect(const Field* fd, const CardStatus* status, c
     unsigned skill_value = 0;
     switch (fd->effect)
     {
+        case Effect::armored_1:
+        case Effect::berserk_1:
+        case Effect::counter_1:
+        case Effect::evade_1:
         case Effect::heal_1:
         case Effect::leech_1:
         case Effect::poison_1:
             skill_value = 1;
             break;
+        case Effect::armored_2:
+        case Effect::berserk_2:
+        case Effect::counter_2:
+        case Effect::evade_2:
         case Effect::heal_2:
         case Effect::leech_2:    
         case Effect::poison_2:
             skill_value = 2;
             break;
+        case Effect::armored_3:
+        case Effect::berserk_3:
+        case Effect::counter_3:
+        case Effect::evade_3:
         case Effect::heal_3:    
         case Effect::leech_3:    
         case Effect::poison_3:
@@ -479,6 +503,42 @@ SkillSpec apply_battleground_effect(const Field* fd, const CardStatus* status, c
     }
     switch (fd->effect)
     {
+        case Effect::armored_1:
+        case Effect::armored_2:
+        case Effect::armored_3:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_armored, skill_value, allfactions, true, mod);
+            }
+            break;
+        case Effect::berserk_1:
+        case Effect::berserk_2:
+        case Effect::berserk_3:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_berserk, skill_value, allfactions, true, mod);
+            }
+            break;
+        case Effect::counter_1:
+        case Effect::counter_2:
+        case Effect::counter_3:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_counter, skill_value, allfactions, true, mod);
+            }
+            break;
+        case Effect::evade_1:
+        case Effect::evade_2:
+        case Effect::evade_3:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_evade, skill_value, allfactions, true, mod);
+            }
+            break;
         case Effect::heal_1:
         case Effect::heal_2:
         case Effect::heal_3:
@@ -487,7 +547,7 @@ SkillSpec apply_battleground_effect(const Field* fd, const CardStatus* status, c
                 need_add_skill = false;
                 return SkillSpec(enhance_heal, skill_value, allfactions, true, mod);
             }
-            break;        
+            break;
         case Effect::leech_1:
         case Effect::leech_2:
         case Effect::leech_3:
@@ -496,7 +556,7 @@ SkillSpec apply_battleground_effect(const Field* fd, const CardStatus* status, c
                 need_add_skill = false;
                 return SkillSpec(enhance_leech, skill_value, allfactions, true, mod);
             }
-            break;        
+            break;
         case Effect::poison_1:
         case Effect::poison_2:
         case Effect::poison_3:
@@ -505,7 +565,7 @@ SkillSpec apply_battleground_effect(const Field* fd, const CardStatus* status, c
                 need_add_skill = false;
                 return SkillSpec(enhance_poison, skill_value, allfactions, true, mod);
             }
-            break;    
+            break;
         case Effect::time_surge:
             // replace other instance of the skill
             if(skill == rush || skill == new_skill)

--- a/sim.cpp
+++ b/sim.cpp
@@ -90,6 +90,13 @@ CardStatus::CardStatus(const Card* card) :
     m_delay(card->m_delay),
     m_diseased(false),
     m_enfeebled(0),
+    m_enhance_armored(0),
+    m_enhance_berserk(0),
+    m_enhance_counter(0),
+    m_enhance_evade(0),
+    m_enhance_heal(0),
+    m_enhance_leech(0),
+    m_enhance_poison(0),
     m_evades_left(card->m_evade),
     m_faction(card->m_faction),
     m_frozen(false),
@@ -106,13 +113,6 @@ CardStatus::CardStatus(const Card* card) :
     m_stunned(0),
     m_sundered(false),
     m_weakened(0),
-    m_enhance_armored(0),
-    m_enhance_heal(0),
-    m_enhance_poison(0),
-    m_enhance_berserk(0),
-    m_enhance_leech(0),
-    m_enhance_counter(0),
-    m_enhance_evade(0),
     m_temporary_split(false),
     m_is_summoned(false),
     m_step(CardStep::none)
@@ -137,6 +137,13 @@ inline void CardStatus::set(const Card& card)
     m_delay = card.m_delay;
     m_diseased = false;
     m_enfeebled = 0;
+    m_enhance_armored = 0;
+    m_enhance_berserk = 0;
+    m_enhance_counter = 0;
+    m_enhance_evade = 0;
+    m_enhance_heal = 0;
+    m_enhance_leech = 0;
+    m_enhance_poison = 0;
     m_evades_left = card.m_evade,
     m_faction = card.m_faction;
     m_frozen = false;
@@ -154,13 +161,6 @@ inline void CardStatus::set(const Card& card)
     m_sundered = false;
     m_temporary_split = false;
     m_weakened = 0;
-    m_enhance_armored = 0;
-    m_enhance_heal = 0;
-    m_enhance_poison = 0;
-    m_enhance_berserk = 0;
-    m_enhance_leech = 0;
-    m_enhance_counter = 0;
-    m_enhance_evade = 0;
     m_is_summoned = false;
     m_step = CardStep::none;
 }
@@ -1273,9 +1273,6 @@ void turn_end_phase(Field* fd)
             ++index)
         {
             CardStatus& status(assaults[index]);
-            //status.m_index = index;
-            //status.m_enfeebled = 0;
-            //status.m_protected = 0;
             status.m_inhibited = 0;
             unsigned diff = safe_minus(status.m_poisoned, status.m_protected);
             //only cards that are still alive take poison damage
@@ -1309,12 +1306,12 @@ void turn_start_phase(Field* fd)
             status.m_protected = 0;
             //reset enhance_...
             status.m_enhance_armored = 0;
-            status.m_enhance_heal = 0;
-            status.m_enhance_poison = 0;
             status.m_enhance_berserk = 0;
-            status.m_enhance_leech = 0;
             status.m_enhance_counter = 0;
             status.m_enhance_evade = 0;
+            status.m_enhance_leech = 0;
+            status.m_enhance_heal = 0;
+            status.m_enhance_poison = 0;
             status.m_evades_left = status.m_card->m_evade;
             if(status.m_delay > 0 && !status.m_frozen)
             {
@@ -2809,6 +2806,13 @@ void fill_skill_table()
     skill_table[chaos] = perform_targetted_hostile_fast<chaos>;
     skill_table[cleanse] = perform_targetted_allied_fast<cleanse>;
     skill_table[enfeeble] = perform_targetted_hostile_fast<enfeeble>;
+    skill_table[enhance_armored] = perform_targetted_allied_fast<enhance_armored>;
+    skill_table[enhance_berserk] = perform_targetted_allied_fast<enhance_berserk>;
+    skill_table[enhance_counter] = perform_targetted_allied_fast<enhance_counter>;
+    skill_table[enhance_evade] = perform_targetted_allied_fast<enhance_evade>;
+    skill_table[enhance_leech] = perform_targetted_allied_fast<enhance_leech>;
+    skill_table[enhance_heal] = perform_targetted_allied_fast<enhance_heal>;
+    skill_table[enhance_poison] = perform_targetted_allied_fast<enhance_poison>;
     skill_table[freeze] = perform_targetted_hostile_fast<freeze>;
     skill_table[heal] = perform_targetted_allied_fast<heal>;
     skill_table[infuse] = perform_infuse;
@@ -2827,11 +2831,4 @@ void fill_skill_table()
     skill_table[summon] = perform_summon<summon>;
     skill_table[trigger_regen] = perform_trigger_regen;
     skill_table[weaken] = perform_targetted_hostile_fast<weaken>;
-    skill_table[enhance_armored] = perform_targetted_allied_fast<enhance_armored>;
-    skill_table[enhance_heal] = perform_targetted_allied_fast<enhance_heal>;
-    skill_table[enhance_poison] = perform_targetted_allied_fast<enhance_poison>;
-    skill_table[enhance_berserk] = perform_targetted_allied_fast<enhance_berserk>;
-    skill_table[enhance_leech] = perform_targetted_allied_fast<enhance_leech>;
-    skill_table[enhance_counter] = perform_targetted_allied_fast<enhance_counter>;
-    skill_table[enhance_evade] = perform_targetted_allied_fast<enhance_evade>;
 }

--- a/sim.cpp
+++ b/sim.cpp
@@ -419,7 +419,10 @@ bool may_change_skill(const Field* fd, const CardStatus* status, const SkillMod:
             switch (status->m_card->m_type)
             {
                 case CardType::commander:
-                    return (fd->effect == Effect::poison_1 ||
+                    return (fd->effect == Effect::leech_1 ||
+                            fd->effect == Effect::leech_2 ||
+                            fd->effect == Effect::leech_3 ||
+                            fd->effect == Effect::poison_1 ||
                             fd->effect == Effect::poison_2 ||
                             fd->effect == Effect::poison_3 ||
                             fd->effect == Effect::time_surge ||
@@ -447,29 +450,44 @@ bool may_change_skill(const Field* fd, const CardStatus* status, const SkillMod:
 SkillSpec apply_battleground_effect(const Field* fd, const CardStatus* status, const SkillSpec& ss, const SkillMod::SkillMod mod, bool& need_add_skill)
 {
     const auto& skill = std::get<0>(ss);
+    unsigned skill_value = 0;
+    switch (fd->effect)
+    {
+        case Effect::leech_1:
+        case Effect::poison_1:
+            skill_value = 1;
+            break;
+        case Effect::leech_2:    
+        case Effect::poison_2:
+            skill_value = 2;
+            break;
+        case Effect::leech_3:    
+        case Effect::poison_3:
+            skill_value = 3;
+            break;
+        default:
+            break;    
+    }
     switch (fd->effect)
     {
         case Effect::poison_1:
-            if(skill == new_skill)
-            {
-                need_add_skill = false;
-                return SkillSpec(enhance_poison, 1, allfactions, true, mod);
-            }
-            break;
         case Effect::poison_2:
-            if(skill == new_skill)
-            {
-                need_add_skill = false;
-                return SkillSpec(enhance_poison, 2, allfactions, true, mod);
-            }
-            break;
         case Effect::poison_3:
             if(skill == new_skill)
             {
                 need_add_skill = false;
-                return SkillSpec(enhance_poison, 3, allfactions, true, mod);
+                return SkillSpec(enhance_poison, skill_value, allfactions, true, mod);
             }
             break;
+        case Effect::leech_1:
+        case Effect::leech_2:
+        case Effect::leech_3:
+            if(skill == new_skill)
+            {
+                need_add_skill = false;
+                return SkillSpec(enhance_leech, skill_value, allfactions, true, mod);
+            }
+            break;            
         case Effect::time_surge:
             // replace other instance of the skill
             if(skill == rush || skill == new_skill)

--- a/sim.h
+++ b/sim.h
@@ -152,6 +152,7 @@ struct CardStatus
     bool m_sundered;
     unsigned m_weakened;
     unsigned m_enhance_armored;
+    unsigned m_enhance_heal;
     unsigned m_enhance_poison;
     unsigned m_enhance_berserk;
     unsigned m_enhance_leech;

--- a/sim.h
+++ b/sim.h
@@ -135,6 +135,13 @@ struct CardStatus
     unsigned m_delay;
     bool m_diseased;
     unsigned m_enfeebled;
+    unsigned m_enhance_armored;
+    unsigned m_enhance_berserk;
+    unsigned m_enhance_counter;
+    unsigned m_enhance_evade;
+    unsigned m_enhance_heal;
+    unsigned m_enhance_leech;
+    unsigned m_enhance_poison;
     unsigned m_evades_left;
     Faction m_faction;
     bool m_frozen;
@@ -151,13 +158,6 @@ struct CardStatus
     unsigned m_stunned;
     bool m_sundered;
     unsigned m_weakened;
-    unsigned m_enhance_armored;
-    unsigned m_enhance_heal;
-    unsigned m_enhance_poison;
-    unsigned m_enhance_berserk;
-    unsigned m_enhance_leech;
-    unsigned m_enhance_counter;
-    unsigned m_enhance_evade;
     bool m_temporary_split;
     bool m_is_summoned; // is this card summoned (or split)?
     CardStep m_step;

--- a/tu_optimize.cpp
+++ b/tu_optimize.cpp
@@ -1112,7 +1112,8 @@ void usage(int argc, char** argv)
         "\n"
         "Flags:\n"
         //"  -A <achievement>: optimize for the achievement specified by either id or name.\n"
-        //"  -e <effect>: set the battleground effect. effect is automatically set when applicable.\n"
+        "  -e <effect>: set the battleground effect.\n"
+        "               use \"tu_optimize Po Po -e test\" to get a list of all available effects.\n" 
         "  -r: the attack deck is played in order instead of randomly (respects the 3 cards drawn limit).\n"
         "  -s: use surge (default is fight).\n"
         "  -t <num>: set the number of threads, default is 4.\n"
@@ -1136,8 +1137,8 @@ void usage(int argc, char** argv)
 #ifndef NDEBUG
         "  debug: testing purpose only. very verbose output. only one battle.\n"
         "  debuguntil <min> <max>: testing purpose only. fight until the last fight results in range [<min>, <max>]. recommend to redirect output.\n"
-        "  example: debuguntil 100 100 will run till first win.\n"
-        "  example: debuguntil 0 0 will run till first lose.\n"
+        "                          debuguntil 100 100 will run till first win.\n"
+        "                          debuguntil 0 0 will run till first lose.\n"
 #endif
         ;
 }

--- a/tu_optimize.cpp
+++ b/tu_optimize.cpp
@@ -1113,7 +1113,7 @@ void usage(int argc, char** argv)
         "Flags:\n"
         //"  -A <achievement>: optimize for the achievement specified by either id or name.\n"
         "  -e <effect>: set the battleground effect.\n"
-        "               use \"tu_optimize Po Po -e test\" to get a list of all available effects.\n" 
+        "               use \"tu_optimize Po Po -e list\" to get a list of all available effects.\n" 
         "  -r: the attack deck is played in order instead of randomly (respects the 3 cards drawn limit).\n"
         "  -s: use surge (default is fight).\n"
         "  -t <num>: set the number of threads, default is 4.\n"
@@ -1166,7 +1166,7 @@ int main(int argc, char** argv)
     if(argc <= 2)
     {
         print_available_decks(decks, true);
-        return(4);
+        return(0);
     }
     std::string att_deck_name{argv[1]};
     auto deck_list_parsed = parse_deck_list(argv[2]);
@@ -1186,7 +1186,7 @@ int main(int argc, char** argv)
     catch(const std::runtime_error& e)
     {
         std::cerr << "Error: Deck " << att_deck_name << ": " << e.what() << std::endl;
-        return(5);
+        return(0);
     }
     if(att_deck == nullptr)
     {
@@ -1200,7 +1200,7 @@ int main(int argc, char** argv)
     if(att_deck == nullptr)
     {
         print_available_decks(decks, false);
-        return(5);
+        return(0);
     }
 
     for(auto deck_parsed: deck_list_parsed)
@@ -1213,13 +1213,13 @@ int main(int argc, char** argv)
         catch(const std::runtime_error& e)
         {
             std::cerr << "Error: Deck " << deck_parsed.first << ": " << e.what() << std::endl;
-            return(5);
+            return(0);
         }
         if(def_deck == nullptr)
         {
             std::cerr << "Error: Invalid defense deck name/hash " << deck_parsed.first << ".\n";
             print_available_decks(decks, true);
-            return(5);
+            return(0);
         }
         if(def_deck->decktype == DeckType::raid)
         {
@@ -1266,19 +1266,19 @@ int main(int argc, char** argv)
             catch(const std::runtime_error& e)
             {
                 std::cerr << "Error: Achievement " << argv[argIndex + 1] << ": " << e.what() << std::endl;
-                return(1);
+                return(0);
             }
             for(auto def_deck: def_decks)
             {
                 if(def_deck->decktype != DeckType::mission)
                 {
                     std::cerr << "Error: Enemy's deck must be mission for achievement." << std::endl;
-                    return(1);
+                    return(0);
                 }
                 if(!achievement.mission_condition.check(def_deck->id))
                 {
                     std::cerr << "Error: Wrong mission [" << def_deck->name << "] for achievement." << std::endl;
-                    return(1);
+                    return(0);
                 }
             }
             argIndex += 1;
@@ -1293,9 +1293,9 @@ int main(int argc, char** argv)
             auto x = effect_map.find(arg_effect);
             if(x == effect_map.end())
             {
-                std::cout << "The effect '" << arg_effect << "' was not found. ";
+                if(strcmp(argv[argIndex + 1], "list") != 0){ std::cout << "The effect '" << arg_effect << "' was not found. "; }
                 print_available_effects();
-                return(6);
+                return(0);
             }
             effect = static_cast<enum Effect>(x->second);
             argIndex += 1;
@@ -1437,7 +1437,7 @@ int main(int argc, char** argv)
         else
         {
             std::cerr << "Error: Unknown option " << argv[argIndex] << std::endl;
-            return(1);
+            return(0);
         }
     }
 

--- a/tu_optimize.cpp
+++ b/tu_optimize.cpp
@@ -1090,7 +1090,8 @@ void print_available_decks(const Decks& decks, bool allow_card_pool)
 void print_available_effects()
 {
     std::cout << "Available effects:" << std::endl;
-    for(int i(1); i < Effect::num_effects; ++ i)
+    //TU workaround: omit all effect starting with time_surge. They are Web Tyrant Specific
+    for(int i(1); i < Effect::time_surge; ++ i)
     {
         std::cout << i << " \"" << effect_names[i] << "\"" << std::endl;
     }

--- a/tyrant.cpp
+++ b/tyrant.cpp
@@ -15,7 +15,8 @@ std::string skill_names[Skill::num_skills] =
     "Mimic", "Protect", "Rally", "Recharge", "Repair", "Rush", "Shock",
     "Siege", "Split", "Strike", "Summon", "Supply",
     "trigger_regen",
-    "Weaken", "Enhance Armored", "Enhance Poison", "Enhance Berserk", "Enhance Leech", "Enhance Counter", "Enhance Evade",
+    "Weaken", "Enhance Armored", "Enhance Heal", "Enhance Poison", "Enhance Berserk", "Enhance Leech", 
+    "Enhance Counter", "Enhance Evade",
     // Combat-Modifier:
     "AntiAir", "Burst", "Fear", "Flurry", "Pierce", "Swipe", "Valor",
     // Damage-Dependant:
@@ -44,6 +45,9 @@ std::string decktype_names[DeckType::num_decktypes]{"Deck", "Mission", "Raid", "
 
 std::string effect_names[Effect::num_effects] = {
     "None",
+    "Heal 1",
+    "Heal 2",
+    "Heal 3",
     "Leech 1",
     "Leech 2",
     "Leech 3",

--- a/tyrant.cpp
+++ b/tyrant.cpp
@@ -44,6 +44,9 @@ std::string decktype_names[DeckType::num_decktypes]{"Deck", "Mission", "Raid", "
 
 std::string effect_names[Effect::num_effects] = {
     "None",
+    "Poison 1",
+    "Poison 2",
+    "Poison 3",
     "Time Surge",
     "Copycat",
     "Quicksilver",

--- a/tyrant.cpp
+++ b/tyrant.cpp
@@ -11,12 +11,13 @@ std::string skill_names[Skill::num_skills] =
     "0",
     // Activation (Including Destroyed):
     "Augment", "Backfire", "Chaos", "Cleanse", "Enfeeble",
+    "Enhance Armored", "Enhance Berserk", "Enhance Counter", "Enhance Evade",
+    "Enhance Leech", "Enhance Heal", "Enhance Poison",
     "Freeze", "Heal", "Infuse", "Jam",
     "Mimic", "Protect", "Rally", "Recharge", "Repair", "Rush", "Shock",
     "Siege", "Split", "Strike", "Summon", "Supply",
     "trigger_regen",
-    "Weaken", "Enhance Armored", "Enhance Heal", "Enhance Poison", "Enhance Berserk", "Enhance Leech", 
-    "Enhance Counter", "Enhance Evade",
+    "Weaken",
     // Combat-Modifier:
     "AntiAir", "Burst", "Fear", "Flurry", "Pierce", "Swipe", "Valor",
     // Damage-Dependant:

--- a/tyrant.cpp
+++ b/tyrant.cpp
@@ -46,6 +46,18 @@ std::string decktype_names[DeckType::num_decktypes]{"Deck", "Mission", "Raid", "
 
 std::string effect_names[Effect::num_effects] = {
     "None",
+    "Armor 1",
+    "Armor 2",
+    "Armor 3",
+    "Berserk 1",
+    "Berserk 2",
+    "Berserk 3",
+    "Counter 1",
+    "Counter 2",
+    "Counter 3",
+    "Evade 1",
+    "Evade 2",
+    "Evade 3",
     "Heal 1",
     "Heal 2",
     "Heal 3",

--- a/tyrant.cpp
+++ b/tyrant.cpp
@@ -44,6 +44,9 @@ std::string decktype_names[DeckType::num_decktypes]{"Deck", "Mission", "Raid", "
 
 std::string effect_names[Effect::num_effects] = {
     "None",
+    "Leech 1",
+    "Leech 2",
+    "Leech 3",
     "Poison 1",
     "Poison 2",
     "Poison 3",

--- a/tyrant.h
+++ b/tyrant.h
@@ -88,6 +88,9 @@ extern std::string decktype_names[DeckType::num_decktypes];
 
 enum Effect {
     none,
+    leech_1,
+    leech_2,
+    leech_3,
     poison_1,
     poison_2,
     poison_3,

--- a/tyrant.h
+++ b/tyrant.h
@@ -1,7 +1,7 @@
 #ifndef TYRANT_H_INCLUDED
 #define TYRANT_H_INCLUDED
 
-#define TU_OPTIMIZER_VERSION "1.0"
+#define TU_OPTIMIZER_VERSION "1.0[RC]"
 
 #include <string>
 #include <set>

--- a/tyrant.h
+++ b/tyrant.h
@@ -88,6 +88,9 @@ extern std::string decktype_names[DeckType::num_decktypes];
 
 enum Effect {
     none,
+    poison_1,
+    poison_2,
+    poison_3,
     time_surge,
     copycat,
     quicksilver,

--- a/tyrant.h
+++ b/tyrant.h
@@ -28,7 +28,8 @@ enum Skill
     augment, backfire, chaos, cleanse, enfeeble, freeze, heal, infuse, jam,
     mimic, protect, rally, recharge, repair, rush, shock, siege, split, strike, summon, supply,
     trigger_regen, // not actually a skill; handles regeneration after strike/siege
-    weaken, enhance_armored, enhance_poison, enhance_berserk, enhance_leech, enhance_counter, enhance_evade,
+    weaken, enhance_armored, enhance_heal, enhance_poison, enhance_berserk, enhance_leech, 
+    enhance_counter, enhance_evade,
     // Combat-Modifier:
     antiair, burst, fear, flurry, pierce, swipe, valor,
     // Damage-Dependant:
@@ -88,6 +89,9 @@ extern std::string decktype_names[DeckType::num_decktypes];
 
 enum Effect {
     none,
+    heal_1,
+    heal_2,
+    heal_3,
     leech_1,
     leech_2,
     leech_3,

--- a/tyrant.h
+++ b/tyrant.h
@@ -25,11 +25,13 @@ enum Skill
     // Attack:
     attack,
     // Activation (including Destroyed):
-    augment, backfire, chaos, cleanse, enfeeble, freeze, heal, infuse, jam,
+    augment, backfire, chaos, cleanse, enfeeble,
+    enhance_armored, enhance_berserk, enhance_counter, enhance_evade,
+    enhance_leech, enhance_heal, enhance_poison,
+    freeze, heal, infuse, jam,
     mimic, protect, rally, recharge, repair, rush, shock, siege, split, strike, summon, supply,
     trigger_regen, // not actually a skill; handles regeneration after strike/siege
-    weaken, enhance_armored, enhance_heal, enhance_poison, enhance_berserk, enhance_leech, 
-    enhance_counter, enhance_evade,
+    weaken,
     // Combat-Modifier:
     antiair, burst, fear, flurry, pierce, swipe, valor,
     // Damage-Dependant:

--- a/tyrant.h
+++ b/tyrant.h
@@ -1,7 +1,7 @@
 #ifndef TYRANT_H_INCLUDED
 #define TYRANT_H_INCLUDED
 
-#define TU_OPTIMIZER_VERSION "0.10.1"
+#define TU_OPTIMIZER_VERSION "1.0"
 
 #include <string>
 #include <set>
@@ -91,6 +91,18 @@ extern std::string decktype_names[DeckType::num_decktypes];
 
 enum Effect {
     none,
+    armored_1,
+    armored_2,
+    armored_3,
+    berserk_1,
+    berserk_2,
+    berserk_3,
+    counter_1,
+    counter_2,
+    counter_3,
+    evade_1,
+    evade_2,
+    evade_3,
     heal_1,
     heal_2,
     heal_3,

--- a/xml.cpp
+++ b/xml.cpp
@@ -347,7 +347,10 @@ void read_cards(Cards& cards)
                         if(strcmp(skill->first_attribute("id")->value(), "freeze") == 0)
                         { handle_skill<freeze>(skill, c); }
                         if(strcmp(skill->first_attribute("id")->value(), "heal") == 0)
-                        { handle_skill<heal>(skill, c); }
+                        { 
+                          c->m_heal = atoi(skill->first_attribute("x")->value());
+                          handle_skill<heal>(skill, c); 
+                        }
                         if(strcmp(skill->first_attribute("id")->value(), "infuse") == 0)
                         { handle_skill<infuse>(skill, c); }
                         if(strcmp(skill->first_attribute("id")->value(), "jam") == 0)
@@ -393,6 +396,8 @@ void read_cards(Cards& cards)
                         { handle_skill<weaken>(skill, c); }
                         if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "armored") == 0))
                         { handle_skill<enhance_armored>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "heal") == 0))
+                        { handle_skill<enhance_heal>(skill, c); }
                         if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "poison") == 0))
                         { handle_skill<enhance_poison>(skill, c); }
                         if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "berserk") == 0))

--- a/xml.cpp
+++ b/xml.cpp
@@ -344,6 +344,27 @@ void read_cards(Cards& cards)
                         { handle_skill<cleanse>(skill, c); }
                         if(strcmp(skill->first_attribute("id")->value(), "enfeeble") == 0)
                         { handle_skill<enfeeble>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) &&
+                           (strcmp(skill->first_attribute("s")->value(), "armored") == 0))
+                        { handle_skill<enhance_armored>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) &&
+                           (strcmp(skill->first_attribute("s")->value(), "berserk") == 0))
+                        { handle_skill<enhance_berserk>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) &&
+                           (strcmp(skill->first_attribute("s")->value(), "counter") == 0))
+                        { handle_skill<enhance_counter>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) &&
+                           (strcmp(skill->first_attribute("s")->value(), "evade") == 0))
+                        { handle_skill<enhance_evade>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) &&
+                           (strcmp(skill->first_attribute("s")->value(), "leech") == 0))
+                        { handle_skill<enhance_leech>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) &&
+                           (strcmp(skill->first_attribute("s")->value(), "heal") == 0))
+                        { handle_skill<enhance_heal>(skill, c); }
+                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) &&
+                           (strcmp(skill->first_attribute("s")->value(), "poison") == 0))
+                        { handle_skill<enhance_poison>(skill, c); }
                         if(strcmp(skill->first_attribute("id")->value(), "freeze") == 0)
                         { handle_skill<freeze>(skill, c); }
                         if(strcmp(skill->first_attribute("id")->value(), "heal") == 0)
@@ -394,20 +415,6 @@ void read_cards(Cards& cards)
                         { handle_skill<supply>(skill, c); }
                         if(strcmp(skill->first_attribute("id")->value(), "weaken") == 0)
                         { handle_skill<weaken>(skill, c); }
-                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "armored") == 0))
-                        { handle_skill<enhance_armored>(skill, c); }
-                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "heal") == 0))
-                        { handle_skill<enhance_heal>(skill, c); }
-                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "poison") == 0))
-                        { handle_skill<enhance_poison>(skill, c); }
-                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "berserk") == 0))
-                        { handle_skill<enhance_berserk>(skill, c); }
-                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "leech") == 0))
-                        { handle_skill<enhance_leech>(skill, c); }
-                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "counter") == 0))
-                        { handle_skill<enhance_counter>(skill, c); }
-                        if((strcmp(skill->first_attribute("id")->value(), "enhance") == 0) && (strcmp(skill->first_attribute("s")->value(), "evade") == 0))
-                        { handle_skill<enhance_evade>(skill, c); }                        
                     }
                     cards.cards.push_back(c);
                 } // end if 


### PR DESCRIPTION
## Version 1.0[RC]
- SimpleTUOptimizeStarter no longer needs quotes
- SimpleTUOptimizeStarter will close all his opened output windows on exit or window close
- SimpleTUOptimizeStarter Help to show build in help
- SimpleTUOptimizeStarter Web to open http://zachanassian.github.io/tu_optimize/
- [FIX] SimpleTUOptimizeStarter output window should no longer close immediatly
- ownedcards.txt single copy of a card no longer requires count (1)
- Added battleground effect Poison 1-3
  <pre>
  tu_optimize.exe "Barracus, Starformer(2)" "Constantine, Vigil(10)" -e "Poison 2" sim 10000
  Your Deck: [SoO6+i] Barracus, Starformer, Starformer
  Enemy's Deck: [S6Cd+q] Constantine, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil, Vigil
  Effect: Poison 2
  win%: 99.75 (9975 / 10000)
  stall%: 0.07 (7 / 10000)
  loss%: 0.18 (18 / 10000)
  </pre>
- Added battleground effect Leech 1-3
  <pre>
  tu_optimize.exe "Nex, Apex(10)" "Obama, SF(5)" -e "Leech 3" sim 1000000
  Your Deck: [S0CC+q] Nexor, Apex, Apex, Apex, Apex, Apex, Apex, Apex, Apex, Apex, Apex
  Enemy's Deck: [SoO6+l] Barracus, Starformer, Starformer, Starformer, Starformer, Starformer
  Effect: Leech 3
  win%: 22.3022 (223022 / 1000000)
  stall%: 1.0532 (10532 / 1000000)
  loss%: 76.6446 (766446 / 1000000)
  </pre>
- Added battleground effect Heal 1-3
  <pre>
  tu_optimize "Alaric, Vigil(5)" "Obama, Terraformer(5)" -e "Heal 1" sim 100000
  Your Deck: [RECd+l] Alaric, Vigil, Vigil, Vigil, Vigil, Vigil
  Enemy's Deck: [SoOe+l] Barracus, Terraformer, Terraformer, Terraformer, Terraformer, Terraformer
  Effect: Heal 1
  win%: 98.553 (98553 / 100000)
  stall%: 1.39 (1390 / 100000)
  loss%: 0.057 (57 / 100000)
  </pre>
- Added battleground effect Evade 1-3
  <pre>
  tu_optimize "Alaric, Blitz(6)" "Barracus, Apex" -e "Evade 1" sim 10000
  Your Deck: [REIJ+m] Alaric, Blitz, Blitz, Blitz, Blitz, Blitz, Blitz
  Enemy's Deck: [SoCC] Barracus, Apex
  Effect: Evade 1
  win%: 100 (10000 / 10000)
  stall%: 0 (0 / 10000)
  loss%: 0 (0 / 10000)
  </pre>
- Added battleground effect Counter 1-3
  <pre>
  tu_optimize "Alaric, Vigil(4)" "Halcyon, Windreaver(5)" -e "Counter 1" sim 10000
  Your Deck: [RECd+k] Alaric, Vigil, Vigil, Vigil, Vigil
  Enemy's Deck: [QEIP+l] Halcyon, Windreaver, Windreaver, Windreaver, Windreaver, Windreaver
  Effect: Counter 1
  win%: 25.08 (2508 / 10000)
  stall%: 1.29 (129 / 10000)
  loss%: 73.63 (7363 / 10000)
  </pre>
- Added battleground effect Berserk 1-3
  <pre>
  tu_optimize "Vex, HA(5)" "Halcyon, Galereaver(3)" -e "Berserk 3" sim 10000
  Your Deck: [QKLQ+l] Typhon Vex, Havoc Alpha, Havoc Alpha, Havoc Alpha, Havoc Alpha, Havoc Alpha
  Enemy's Deck: [QE-QB+j] Halcyon, Galereaver, Galereaver, Galereaver
  Effect: Berserk 3
  win%: 11.92 (1192 / 10000)
  stall%: 15.05 (1505 / 10000)
  loss%: 73.03 (7303 / 10000)
  </pre>
- Added battleground effect Armor 1-3
  <pre>
  tu_optimize "Alaric, Vigil(3)" "Obama, Apex(5)" -e "Armor 2" sim 10000
  Your Deck: [RECd+j] Alaric, Vigil, Vigil, Vigil
  Enemy's Deck: [SoCC+l] Barracus, Apex, Apex, Apex, Apex, Apex
  Effect: Armored 2
  win%: 73.12 (7312 / 10000)
  stall%: 25.31 (2531 / 10000)
  loss%: 1.57 (157 / 10000)
  </pre>
