### PR TITLE
Compilation fixes for OS X:

### DIFF
--- a/achievement.h
+++ b/achievement.h
@@ -58,8 +58,9 @@ public:
     }
 };
 
-struct Achievement
+class Achievement
 {
+public:
     unsigned id;
     std::string name;
     Counter mission_condition;

--- a/cards.h
+++ b/cards.h
@@ -7,8 +7,9 @@
 
 class Card;
 
-struct Cards
+class Cards
 {
+public:
     ~Cards();
 
     std::vector<Card*> cards;

--- a/deck.cpp
+++ b/deck.cpp
@@ -10,6 +10,8 @@
 #include "cards.h"
 #include "read.h"
 
+std::map<signed, char> empty_marks;
+
 template<class RandomAccessIterator, class UniformRandomNumberGenerator>
 void partial_shuffle(RandomAccessIterator first, RandomAccessIterator middle,
                      RandomAccessIterator last,
@@ -177,7 +179,7 @@ const std::pair<std::vector<unsigned>, std::map<signed, char>> string_to_ids(con
 
 namespace range = boost::range;
 
-void Deck::set(const Cards& all_cards, const std::vector<unsigned>& ids, const std::map<signed, char> marks)
+void Deck::set(const Cards& all_cards, const std::vector<unsigned>& ids, const std::map<signed, char> &marks)
 {
     commander = nullptr;
     strategy = DeckStrategy::random;

--- a/deck.h
+++ b/deck.h
@@ -29,8 +29,12 @@ enum DeckStrategy
 }
 //------------------------------------------------------------------------------
 // No support for ordered raid decks
-struct Deck
+
+
+extern std::map<signed, char> empty_marks;
+class Deck
 {
+public:
     DeckType::DeckType decktype;
     unsigned id;
     std::string name;
@@ -82,7 +86,7 @@ struct Deck
         mission_req = mission_req_;
     }
 
-    void set(const Cards& all_cards, const std::vector<unsigned>& ids, const std::map<signed, char> marks = {});
+    void set(const Cards& all_cards, const std::vector<unsigned>& ids, const std::map<signed, char> &marks = empty_marks);
     void set(const Cards& all_cards, const std::string& deck_string_);
     void resolve(const Cards& all_cards);
     void set_given_hand(const Cards& all_cards, const std::string& deck_string_);
@@ -110,8 +114,9 @@ struct Deck
 };
 
 // + also the custom decks
-struct Decks
+class Decks
 {
+public:
     std::list<Deck> decks;
     std::map<std::pair<DeckType::DeckType, unsigned>, Deck*> by_type_id;
     std::map<std::string, Deck*> by_name;

--- a/read.cpp
+++ b/read.cpp
@@ -29,7 +29,7 @@ std::vector<std::pair<std::string, long double>> parse_deck_list(std::string lis
     {
         boost::tokenizer<boost::char_delimiters_separator<char>> deck_tokens{*list_token, boost::char_delimiters_separator<char>{false, ":", ""}};
         auto deck_token = deck_tokens.begin();
-        res.push_back(std::make_pair(*deck_token, 1.0d));
+        res.push_back(std::make_pair(*deck_token, 1.0));
         ++deck_token;
         if(deck_token != deck_tokens.end())
         {

--- a/sim.cpp
+++ b/sim.cpp
@@ -1132,12 +1132,6 @@ inline bool skill_check<evade>(Field* fd, CardStatus* c, CardStatus* ref)
     return(c->m_player != ref->m_player);
 }
 
-template<>
-inline bool skill_check<flying>(Field* fd, CardStatus* c, CardStatus* ref)
-{
-    return(!ref->m_card->m_flying && !ref->m_card->m_antiair > 0);
-}
-
 // Not yet support on Attacked/on Death.
 template<>
 inline bool skill_check<immobilize>(Field* fd, CardStatus* c, CardStatus* ref)

--- a/sim.cpp
+++ b/sim.cpp
@@ -1132,6 +1132,12 @@ inline bool skill_check<evade>(Field* fd, CardStatus* c, CardStatus* ref)
     return(c->m_player != ref->m_player);
 }
 
+template<>
+inline bool skill_check<flying>(Field* fd, CardStatus* c, CardStatus* ref)
+{
+    return(!ref->m_card->m_flying && !(ref->m_card->m_antiair > 0));
+}
+
 // Not yet support on Attacked/on Death.
 template<>
 inline bool skill_check<immobilize>(Field* fd, CardStatus* c, CardStatus* ref)

--- a/sim.h
+++ b/sim.h
@@ -7,6 +7,7 @@
 #include <deque>
 #include <tuple>
 #include <vector>
+#include <random>
 
 #include "tyrant.h"
 

--- a/tu_optimize.cpp
+++ b/tu_optimize.cpp
@@ -423,7 +423,7 @@ void thread_evaluate(boost::barrier& main_barrier,
                         {
                             score_accum_d += thread_score_local[i] * sim.factors[i];
                         }
-                        score_accum_d /= std::accumulate(sim.factors.begin(), sim.factors.end(), .0d);
+                        score_accum_d /= std::accumulate(sim.factors.begin(), sim.factors.end(), .0);
                         score_accum = score_accum_d;
                     }
                     else


### PR DESCRIPTION
- consistent class/struct
- X.XXd float literals ==> X.XX
- remove unused skill_check template function (produced error)
- include missing header.
