### PR TITLE
Parse owned cards as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Flags for climb:
   -o: restrict to the owned cards listed in "data/ownedcards.txt".
   -o=&lt;filename&gt;: restrict to the owned cards listed in &lt;filename&gt;.
                        example: -o=data/mycards.txt.
+  -o=&lt;cards&gt;: restrict to the owned cards specified.
+                 example: -o="Sacred Equalizer#2, Infantry".
   target &lt;num&gt;: stop as soon as the score reaches &lt;num&gt;.
 
 Operations:

--- a/read.cpp
+++ b/read.cpp
@@ -306,12 +306,54 @@ unsigned read_custom_decks(Decks& decks, Cards& cards, std::string filename)
     return(0);
 }
 
+void add_owned_card(Cards& cards, std::map<unsigned, unsigned>& owned_cards, std::string& card_spec, std::map<unsigned, unsigned>& buyable_cards)
+{
+    unsigned card_id{0};
+    unsigned card_num{1};
+    char num_sign{0};
+    char mark{0};
+    parse_card_spec(cards, card_spec, card_id, card_num, num_sign, mark);
+    assert(mark == 0);
+    if(num_sign == 0)
+    {
+        owned_cards[card_id] = card_num;
+    }
+    else if(num_sign == '+')
+    {
+        owned_cards[card_id] += card_num;
+    }
+    else if(num_sign == '-')
+    {
+        owned_cards[card_id] = owned_cards[card_id] > card_num ? owned_cards[card_id] - card_num : 0;
+    }
+    else if(num_sign == '$')
+    {
+        buyable_cards[card_id] = card_num;
+    }
+}
+
 void read_owned_cards(Cards& cards, std::map<unsigned, unsigned>& owned_cards, std::map<unsigned, unsigned>& buyable_cards, const char *filename)
 {
     std::ifstream owned_file{filename};
     if(!owned_file.good())
     {
-        std::cerr << "Warning: Owned cards file '" << filename << "' does not exist.\n";
+        // try parse the string as a cards instead of as a filename
+        try 
+        {
+            std::string card_list(filename);
+            boost::tokenizer<boost::char_delimiters_separator<char>> card_tokens{card_list, boost::char_delimiters_separator<char>{false, ":,", ""}};
+            auto token_iter = card_tokens.begin();
+            for (; token_iter != card_tokens.end(); ++token_iter)
+            {
+                std::string card_spec(*token_iter);
+                // try catch TODO
+                add_owned_card(cards, owned_cards, card_spec, buyable_cards);
+            }
+        } 
+        catch (std::exception& e)
+        {
+            std::cerr << "Warning: Failed to parse owned cards: '" << filename << "' is neither a file nor a valid set of cards (" << e.what() << ")" << std::endl;
+        }
         return;
     }
     unsigned num_line(0);
@@ -326,28 +368,7 @@ void read_owned_cards(Cards& cards, std::map<unsigned, unsigned>& owned_cards, s
         }
         try
         {
-            unsigned card_id{0};
-            unsigned card_num{1};
-            char num_sign{0};
-            char mark{0};
-            parse_card_spec(cards, card_spec, card_id, card_num, num_sign, mark);
-            assert(mark == 0);
-            if(num_sign == 0)
-            {
-                owned_cards[card_id] = card_num;
-            }
-            else if(num_sign == '+')
-            {
-                owned_cards[card_id] += card_num;
-            }
-            else if(num_sign == '-')
-            {
-                owned_cards[card_id] = owned_cards[card_id] > card_num ? owned_cards[card_id] - card_num : 0;
-            }
-            else if(num_sign == '$')
-            {
-                buyable_cards[card_id] = card_num;
-            }
+            add_owned_card(cards, owned_cards, card_spec, buyable_cards);
         }
         catch(std::exception& e)
         {

--- a/tu_optimize.cpp
+++ b/tu_optimize.cpp
@@ -1138,6 +1138,8 @@ void usage(int argc, char** argv)
         "  -o: restrict to the owned cards listed in \"data/ownedcards.txt\".\n"
         "  -o=<filename>: restrict to the owned cards listed in <filename>.\n"
         "                 example: -o=data/mycards.txt.\n"
+        "  -o=<cards>: restrict to the owned cards specified.\n"
+        "                 example: -o=\"Sacred Equalizer#2, Infantry\".\n"
         //"  fund <num>: fund <num> gold to buy/upgrade cards. prices are specified in ownedcards file.\n"
         "  target <num>: stop as soon as the score reaches <num>.\n"
         //"  -u: don't upgrade owned cards. (by default, upgrade owned cards when needed)\n"


### PR DESCRIPTION
Change -o=XXX to parse XXX as cards if XXX cannot be opened as a file.
